### PR TITLE
Mpd 11020 test and upgrade tap turnio packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,3 +218,6 @@ __marimo__/
 # Meltano dev files
 dev-files/
 data-ingestion/
+
+# Temporary files
+notes

--- a/.gitignore
+++ b/.gitignore
@@ -221,3 +221,6 @@ data-ingestion/
 
 # Temporary files
 notes
+plugins
+*.sample
+meltano.yml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,22 +11,22 @@ packages = [{ include = "tap_turnio" }]
 [tool.poetry.dependencies]
 # Uses PEP 604 unions (|), so require 3.10+
 python = "^3.10"
-singer-sdk = { version = "0.52.5", extras = ["testing"] }
+singer-sdk = { version = "0.54.5", extras = ["testing"] }
 requests = "^2.31.0"
 python-dotenv = "^1.0.0"
 python-dateutil = "^2.8.2"
-setuptools = "<81"
+setuptools = "<84"
 pendulum = ">=3.1"
 
 # ------- OPTIONAL deps so pip extras work -------
 pytest = { version = ">=7.5,<10.0", optional = true }
-ruff = { version = "^0.14.2", optional = true }
+ruff = { version = ">=0.14.2,<0.17.0", optional = true }
 pre-commit = { version = "^4.3.0", optional = true }
 
 [tool.poetry.group.dev.dependencies]
 # Keep Poetry's dev group for people using Poetry
 pytest = ">=7.5,<10.0"
-ruff = "^0.14.2"
+ruff = ">=0.14.2,<0.17.0"
 pre-commit = "^4.3.0"
 
 # Expose a 'dev' extra that pip can install


### PR DESCRIPTION
Update ruff, setuptools, and singer-sdk dependencies

- Update ruff requirement from ^0.14.2 to >=0.14.2,<0.17.0
- Update setuptools requirement from <81 to <84
- Update singer-sdk requirement from 0.52.5 to 0.54.5
